### PR TITLE
CI/CD again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 os: linux
 dist: bionic
-language: python
-python:
-- "3.8"
+language: minimal
 
 # prevent branch builds that aren't PRs
 branches:
@@ -16,24 +14,13 @@ env:
 after_failure:
 - bash ./ci/discord_hook.sh failure ${WEBHOOK_URL}
 
-addons:
-  apt:
-    packages:
-    - doxygen
-
 cache:
   directories:
   - .git/lfs
-  - rls_win64
-  - rls_linux64
-  - rls_mac
 
 git:
   depth: 25  # warning: tags more than this many commits ago will be lost!
   lfs_skip_smudge: true
-
-services:
-- docker
 
 stages:
 - test
@@ -48,6 +35,8 @@ jobs:
   - stage: test
     name: "Tests"
     if: type == pull_request
+    services:
+    - docker
     script:
     - source ./ci/travis_prepare_workspace.sh
     - bash ./ci/travis_run_tests.sh
@@ -61,6 +50,13 @@ jobs:
     name: "Doxygen"
     script: bash ./ci/generate_docs.sh
     if: type != pull_request
+    language: python
+    python:
+    - "3.8"
+    addons:
+      apt:
+        packages:
+        - doxygen
     deploy:
       provider: pages:git
       token: $GITHUB_TOKEN
@@ -89,6 +85,13 @@ jobs:
     - bash ./ci/package_build.sh linux64
     name: "Build and cache Linux64 (OpenGL)"
     if: type != pull_request
+    services:
+    - docker
+    workspaces:
+      create:
+        name: linux64
+        paths:
+        - rls_linux64
 
   ############
   # Windows 64
@@ -101,6 +104,13 @@ jobs:
     - bash ./ci/package_build.sh win64
     name: "Build and cache Windows64 (OpenGL)"
     if: type != pull_request
+    services:
+    - docker
+    workspaces:
+      create:
+        name: win64
+        paths:
+        - rls_win64
 
   ############
   # mac
@@ -113,18 +123,30 @@ jobs:
     - bash ./ci/package_build.sh mac
     name: "Build and cache macOS (OpenGL)"
     if: type != pull_request
+    services:
+    - docker
+    workspaces:
+      create:
+        name: mac
+        paths:
+        - rls_mac
 
 ################################################################################
 
   - stage: deploy
     script:
-    - ls -la rls*
-    - source ./ci/verify_package.sh linux64
-    - source ./ci/verify_package.sh win64
-    - source ./ci/verify_package.sh mac
-    - bash ./ci/travis_set_tag.sh
+    - ls -la *
+    - source ./ci/verify_package.sh linux64 || travis_terminate 1
+    - source ./ci/verify_package.sh win64 || travis_terminate 1
+    - source ./ci/verify_package.sh mac || travis_terminate 1
+    - bash ./ci/travis_set_tag.sh || travis_terminate 1
     name: Publish release to GitHub
     if: type != pull_request
+    workspaces:
+      use:
+      - linux64
+      - win64
+      - mac
     deploy:
       provider: releases
       api_key: $GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ addons:
 cache:
   directories:
   - .git/lfs
-  - rls
+  - rls_win64
+  - rls_linux64
+  - rls_mac
 
 git:
   depth: 25  # warning: tags more than this many commits ago will be lost!
@@ -116,10 +118,10 @@ jobs:
 
   - stage: deploy
     script:
-    - ls -la rls
-    - bash ./ci/verify_package.sh linux64
-    - bash ./ci/verify_package.sh win64
-    - bash ./ci/verify_package.sh mac
+    - ls -la rls*
+    - source ./ci/verify_package.sh linux64
+    - source ./ci/verify_package.sh win64
+    - source ./ci/verify_package.sh mac
     - bash ./ci/travis_set_tag.sh
     name: Publish release to GitHub
     if: type != pull_request
@@ -132,6 +134,6 @@ jobs:
       overwrite: true
       prerelease: true
       file:
-      - rls/FiscalShock-linux64.tar.gz
-      - rls/FiscalShock-win64.zip
-      - rls/FiscalShock-mac.tar.gz
+      - rls_linux64/FiscalShock-linux64.tar.gz
+      - rls_win64/FiscalShock-win64.zip
+      - rls_mac/FiscalShock-mac.tar.gz

--- a/ci/generate_docs.sh
+++ b/ci/generate_docs.sh
@@ -8,6 +8,7 @@ echo Generating documentation...
 pushd .
 cd sphinx
 pip install -r requirements.txt
+git lfs pull -I ../fiscal-shock/Assets/UserInterface/dmr-icon128.png
 make html
 popd
 touch docs/html/.nojekyll

--- a/ci/package_build.sh
+++ b/ci/package_build.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-mkdir -p rls
-echo `git log -1 @ --pretty="%H"` > rls/$1_head
+mkdir -p rls_$1
+echo `git log -1 @ --pretty="%H"` > rls_$1/$1_head
 pushd .
 cd Builds
 
 case $1 in
     win64)
-        zip -r -9 ../rls/FiscalShock-$1.zip FiscalShock-$1;;
+        zip -r -9 ../rls_$1/FiscalShock-$1.zip FiscalShock-$1;;
     *)
-        tar -czf ../rls/FiscalShock-$1.tar.gz FiscalShock-$1;;
+        tar -czf ../rls_$1/FiscalShock-$1.tar.gz FiscalShock-$1;;
 esac
 
 popd

--- a/ci/travis_set_tag.sh
+++ b/ci/travis_set_tag.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+if [[ "$BAD_PACKAGE" == 1 ]]; then
+    echo At least one package could not be verified to match this commit. Aborting release tag operation.
+    exit 1
+fi
+
 echo -e "machine github.com\n  login $GITHUB_TOKEN" > ~/.netrc
 
 echo Listing all tags.
 git tag
 export COMMIT_HASH="$(git log --format=%h -1)"
-echo Latest tagged version: `git tag -l v* | tail -n 1`
+echo Latest tagged version: `git tag -l v* --sort=taggerdate | tail -n 1`
 export MAJOR_VER=0  # this is 0 until maybe milestone 3
-export MINOR_VER=`git tag -l v* | tail -n 1 | perl -p0e 's/v\d+\.(\d+)\.(\d+)/\1/'`
+export MINOR_VER=`git tag -l v* --sort=taggerdate | tail -n 1 | perl -p0e 's/v\d+\.(\d+)\.(\d+)/\1/'`
 echo Minor version number: ${MINOR_VER}
-export PATCH_VER=`git tag -l v* | tail -n 1 | perl -p0e 's/v\d+\.(\d+)\.(\d+)/\2/'`
+export PATCH_VER=`git tag -l v* --sort=taggerdate | tail -n 1 | perl -p0e 's/v\d+\.(\d+)\.(\d+)/\2/'`
 echo Patch version number: ${PATCH_VER}
 export PSEM_VER=`echo v${MAJOR_VER}.${MINOR_VER}.$(( PATCH_VER + 1 ))`
 echo Next version tag is ${PSEM_VER}

--- a/ci/verify_package.sh
+++ b/ci/verify_package.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 CURRENT_HEAD=`git log -1 @ --pretty="%H"`
-PACKAGE_HEAD=`cat rls/$1_head`
+export PACKAGE_HEAD=`cat rls_$1/$1_head`
 
 if [[ "${CURRENT_HEAD}" == "${PACKAGE_HEAD}" ]]; then
     echo Packaged release is for this commit, continuing with deploy.
+    export PACKAGE_HEAD=''
 else
     echo Packaged release is NOT for this commit!
     echo ========================================
@@ -15,5 +16,7 @@ else
     git log -1 ${PACKAGE_HEAD}
     echo ========================================
     echo Aborting deployment.
+    export BAD_PACKAGE=1
+    export PACKAGE_HEAD=''
     exit 1
 fi


### PR DESCRIPTION
If this doesn't work I'll go insane

Due to the jobs running concurrently and all using the same cache, they'd all overwrite the cache when they finish. The cache is really just a compressed tarball, not a directory somewhere. That's why it would blow away everything that was just placed in there, since it wasn't there when the job started.

I thought this solution would remove the race condition but as I'm typing this I probably wasted more time and it's *still the same cache* and the cache has to be shared among all of them to be used by the release job. If this doesn't work, I am going to disable the concurrency on the Travis side (does not require another PR) and it will just take 45 minutes for the builds on master to finish.

Actually, the work was not entirely wasted. I assumed that `git tag` showed tags in chronological order, but it's alphanumeric, so I ran into a failed deploy for what should have been 0.1.11 because 0.1.9 was at the bottom, not 0.1.10, in the default order.

The only other alternative I can think of to this is to waste a free trial on aws s3 buckets and use that to push/pull the build artifacts just to get the release up, or find somewhere I can push them via command line and also pull them later (too much hassle).

* [travis](https://travis-ci.com/github/pagewin/dmr-capstone/builds/153107407)
* [releases](https://github.com/pagewin/dmr-capstone/releases) (yes there's an old draft, left it up as a test to see if things would break)
